### PR TITLE
Fix the top-level imports to actually work

### DIFF
--- a/Intro_Inference.ipynb
+++ b/Intro_Inference.ipynb
@@ -15,7 +15,10 @@
       "%matplotlib inline\n",
       "import numpy\n",
       "import astropy.io.fits as fitsio\n",
-      "figsize(8,6)"
+      "from matplotlib import rcParams\n",
+      "rcParams['figure.figsize'] = (8, 6)\n",
+      "# \"import *\" is generally bad practice, but sometimes just too convinient...\n",
+    "from matplotlib.pyplot import *  "
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Intro_Inference currently uses a non-existing function (figsize) - this updates to do _I think_ what's intended.  It also adds the needed `from matplotlib.pyplot import *`
